### PR TITLE
Fix 'Try Now' link

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -272,7 +272,7 @@
 				<div class="col-md-3 col-md-push-1">
 					<h3>Quick Links</h3>
 					<ul>
-						<li><a href="https://mariejs.xyz">Try Now</a></li>
+						<li><a href="/MARIE.js/">Try Now</a></li>
 						<li><a href="https://gitter.im/MARIE-js/Support">Support</a></li>
 					</ul>
 				</div>

--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
 				<div class="col-md-3 col-md-push-1">
 					<h3>Quick Links</h3>
 					<ul>
-						<li><a href="https://mariejs.xyz">Try Now</a></li>
+						<li><a href="/MARIE.js/">Try Now</a></li>
 						<li><a href="https://gitter.im/MARIE-js/Support">Support</a></li>
 					</ul>
 				</div>

--- a/v1.0.0.html
+++ b/v1.0.0.html
@@ -153,7 +153,7 @@
 				<div class="col-md-3 col-md-push-1">
 					<h3>Quick Links</h3>
 					<ul>
-						<li><a href="https://mariejs.xyz">Try Now</a></li>
+						<li><a href="/MARIE.js/">Try Now</a></li>
 						<li><a href="https://gitter.im/MARIE-js/Support">Support</a></li>
 					</ul>
 				</div>


### PR DESCRIPTION
marie.xyz is gone, but the footer on each page still links to it as "Try Now"
